### PR TITLE
Modify always not changed by 'Check if selinux is installed' task

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -3,6 +3,7 @@
 - name: Check if selinux is installed
   command: getenforce
   register: command_result
+  changed_when: False
   ignore_errors: True
 
 - name: Install libselinux-python


### PR DESCRIPTION
**Check if selinux is installed**  実行時に毎回変更扱いとなってしまっていたので、 `changed_when: False` として常に`"changed": false` となるようにしました。
- log(修正前)

``` log
TASK: [distkloc.gitbucket | Check if selinux is installed] ********************
changed: [192.168.2.20] => {"changed": true, "cmd": ["getenforce"], "delta": "0:00:00.001755", "end": "2015-06-02 08:31:16.582944", "rc": 0, "start": "2015-06-02 08:31:16.581189", "stderr": "", "stdout": "Permissive", "warnings": []}
```
- log(修正後)

``` log
TASK: [ansible-role-gitbucket | Check if selinux is installed] ****************
ok: [192.168.2.20] => {"changed": false, "cmd": ["getenforce"], "delta": "0:00:00.002105", "end": "2015-06-02 08:53:56.906354", "rc": 0, "start": "2015-06-02 08:53:56.904249", "stderr": "", "stdout": "Permissive", "stdout_lines": ["Permissive"], "warnings": []}
```
